### PR TITLE
Make it easier to use a different node version.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Custom Node.js cartridge for OpenShift
 
-This is a custom Node.js cartridge that **takes care of auto-updating to the latest stable Node.js and NPM versions** on each build.
+This is a custom Node.js cartridge that **takes care of auto-updating to the latest Node.js and NPM versions** on each build. By default, the node version is determined by querying https://semver.io/node/stable. A different URL can be specified in your application's repository, in the `.openshift/NODE_VERSION_URL` file.
 
 ## Why
 

--- a/lib/util
+++ b/lib/util
@@ -1,12 +1,26 @@
 #!/bin/bash
 
 function update_nodejs {
-  local LATEST="v$(curl https://semver.io/node/stable)"
+  if [ -f "$OPENSHIFT_REPO_DIR/.openshift/NODE_VERSION_URL" ]; then
+    local VERSION_URL=$(cat $OPENSHIFT_REPO_DIR/.openshift/NODE_VERSION_URL)
+  else
+    local VERSION_URL="https://semver.io/node/stable"
+  fi
+
+  local LATEST="v$(curl --silent --max-time 5 ${VERSION_URL})"
+  local NODE_URL=https://nodejs.org/dist/${LATEST}/node-${LATEST}-linux-x64.tar.gz
+
+  if [ "$LATEST" = "v" ]; then
+    echo "Could not retrieve node version information from $VERSION_URL"
+    return 1
+  fi
 
   # Update Node.js if necessary
   if [ $(node --version) != ${LATEST} ]; then
     # Download
-    curl -L -o ${OPENSHIFT_DATA_DIR}tmp.tgz http://nodejs.org/dist/${LATEST}/node-${LATEST}-linux-x64.tar.gz
+    if ! curl -L -o ${OPENSHIFT_DATA_DIR}tmp.tgz $NODE_URL; then
+      return 1
+    fi
 
     # Remove old files
     rm -rf ${OPENSHIFT_DATA_DIR}.nodejs

--- a/usr/template/app.js
+++ b/usr/template/app.js
@@ -2,7 +2,7 @@ var http = require('http'),
     env  = process.env,
     server = http.createServer(function(req, res) {
       res.writeHead(200);
-      res.end('Process ' + process.pid + ' says hi!');
+      res.end('Process ' + process.pid + ' says hi (node ' + process.version + ')!');
     });
 
 server.listen(


### PR DESCRIPTION
Changes:
1. Possibility to specify a different URL to query the desired node version.
   The URL has to be put in the `.openshift/NODE_VERSION_URL` file, in the
   application's repository.
2. Also add guards against semver.io and nodejs.org being down. They
   should prevent deletion of the node installation directory in case
   the mentioned hosts are not responding.
3. Download the release from https://nodejs.org instead of
   http://nodejs.org
