### PR TITLE
Node.js 4.2.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Go to [Choose a type of application](https://openshift.redhat.com/app/console/ap
 
 - Can't guarantee this cartridge is production-ready. Some people use it though (on **their own responsibility**).
 - This is a lean cartridge. No unnecessary modules are installed. Which means that - unlike the standard Node.js cartridge - it won't install [supervisor](https://github.com/isaacs/node-supervisor) for you. You'll have to implement your own logic to auto-restart on errors. The [provided application template](https://github.com/icflorescu/openshift-cartridge-nodejs/blob/master/usr/template/start.js) is using [cluster](http://nodejs.org/api/cluster.html) for that.
-- The cartridge will run `node --harmony start.js` on start, so **make sure your application entrypoint is `start.js`**.
+- The cartridge will run `node start.js` on start, so **make sure your application entrypoint is `start.js`**.
 
 ## FAQ
 

--- a/bin/control
+++ b/bin/control
@@ -4,7 +4,7 @@ source $OPENSHIFT_CARTRIDGE_SDK_BASH
 source $HOME/nodejs/lib/util
 
 function is_running() {
-  if [ ! -z "$(ps -ef | grep 'node --harmony start.js' | grep -v grep)" ]; then
+  if [ ! -z "$(ps -ef | grep 'node start.js' | grep -v grep)" ]; then
     return 0
   else
     return 1
@@ -37,7 +37,7 @@ function start() {
     client_result 'Application is already running.'
   else
     client_message 'Starting Node.js application...'
-    nohup node --harmony start.js |& /usr/bin/logshifter -tag nodejs &
+    nohup node start.js |& /usr/bin/logshifter -tag nodejs &
     i=0
     while ! is_running && [ $i -lt 60 ]; do
       sleep 1
@@ -58,7 +58,7 @@ function stop() {
     client_result 'Application is already stopped.'
   else
     client_message 'Stopping Node.js application...'
-    kill $(ps -ef | grep 'node --harmony start.js' | grep -v grep | awk '{ print $2 }') > /dev/null 2>&1
+    kill $(ps -ef | grep 'node start.js' | grep -v grep | awk '{ print $2 }') > /dev/null 2>&1
     i=0
     while is_running && [ $i -lt 60 ]; do
       sleep 1

--- a/metadata/manifest.yml
+++ b/metadata/manifest.yml
@@ -1,14 +1,14 @@
 ---
 Name: nodejs
 Description: Custom Node.js cartridge auto-updating to the latest stable version on each build.
-Version: '4.1.1'
+Version: '4.2.1'
 License: Node.js License
 License-Url: https://raw.github.com/joyent/node/v0.12/LICENSE
 Vendor: www.nodejs.org
 Website: http://www.nodejs.org/
 Display-Name: Node.js Auto-Updating
 Cartridge-Short-Name: NODEJS
-Cartridge-Version: '1.3.0'
+Cartridge-Version: '1.3.1'
 Cartridge-Vendor: icflorescu
 Categories:
 - service


### PR DESCRIPTION
The `--harmony` flag is no longer needed (all the stable _harmony_ features are enabled by default).
