### PR TITLE
Fix issue with updating

### DIFF
--- a/bin/control
+++ b/bin/control
@@ -6,7 +6,7 @@ source $HOME/nodejs/lib/util
 function is_running() {
   npm install jsonfile
   export start_command=$(node -e 'var jsonfile = require("jsonfile"); jsonfile.readFile("package.json", function(err, data) { console.log(data.scripts.start); });')
-  if [ ! -z "$(ps -ef | grep "start_command" | grep -v grep)" ]; then
+  if [ ! -z "$(ps -ef | grep "$start_command" | grep -v grep)" ]; then
     return 0
   else
     return 1

--- a/bin/control
+++ b/bin/control
@@ -4,7 +4,9 @@ source $OPENSHIFT_CARTRIDGE_SDK_BASH
 source $HOME/nodejs/lib/util
 
 function is_running() {
-  if [ ! -z "$(ps -ef | grep 'npm start' | grep -v grep)" ]; then
+  npm install jsonfile
+  export start_command=$(node -e 'var jsonfile = require("jsonfile"); jsonfile.readFile("package.json", function(err, data) { console.log(data.scripts.start); });')
+  if [ ! -z "$(ps -ef | grep "start_command" | grep -v grep)" ]; then
     return 0
   else
     return 1

--- a/bin/control
+++ b/bin/control
@@ -4,8 +4,8 @@ source $OPENSHIFT_CARTRIDGE_SDK_BASH
 source $HOME/nodejs/lib/util
 
 function is_running() {
-  npm install jsonfile
-  export start_command=$(node -e 'var jsonfile = require("jsonfile"); jsonfile.readFile("package.json", function(err, data) { console.log(data.scripts.start); });')
+  cd ${OPENSHIFT_REPO_DIR}
+  export start_command=$(node -e 'var package = require("./package.json"); console.log(package.scripts.start);')
   if [ ! -z "$(ps -ef | grep "$start_command" | grep -v grep)" ]; then
     return 0
   else


### PR DESCRIPTION
Fix for #10. Instead of hardcoding a `grep` for `npm start`, the control script now parses the command ran by `npm start` and `grep`'s for that instead.
