### PR TITLE
Allow specifying the NPM version via a marker or environment variable.

### DIFF
--- a/lib/util
+++ b/lib/util
@@ -37,8 +37,20 @@ function update_nodejs {
   fi
 
   # Update global npm if necessary
-  if [ $(npm view npm version) != $(npm --version) ]; then
-    npm i -g npm
+  if [ -z "$NPM_VERSION_URL" ]; then
+    if [ -f "$OPENSHIFT_REPO_DIR/.openshift/NPM_VERSION_URL" ]; then
+      local NPM_VERSION_URL=$(cat $OPENSHIFT_REPO_DIR/.openshift/NPM_VERSION_URL)
+    fi
+  fi
+
+  if [ -n "$NPM_VERSION_URL" ]; then
+    local NPM_WANTED_VERSION=$(curl --silent --max-time 5 ${NPM_VERSION_URL})
+  else
+    local NPM_WANTED_VERSION=$(npm view npm version)
+  fi
+
+  if [ $NPM_WANTED_VERSION != $(npm --version) ]; then
+    npm i -g npm@${NPM_WANTED_VERSION}
     echo "Npm updated to $(npm --version)."
   fi
 }


### PR DESCRIPTION
This is an attempt to solve #22. A npm version can be set either via the `NPM_VERSION_URL` environment variable or by setting the `.openshift/NPM_VERSION_URL` marker.

Two things might be worth discussing:
1. I also allow setting the npm version via an environment variable. This is a direct result of #23, not sure whether you want to include this.
2. In theory there is no need to use a semver.io URL, npm install could resolve the version. So instead of setting an URL we could just allow setting the version and npm would handle something like `npm install -g npm@3.5.x`. The reason I chose the URL approach anyway are:
   
   a) It is consistent on how the node version gets resolved
   b) It is more flexible, e.g. I could run my own service where I can configure the node and npm version to use for all my gears
