### PR TITLE
Speedup the pre-repo-archive and build commands

### DIFF
--- a/bin/control
+++ b/bin/control
@@ -16,9 +16,8 @@ function is_running() {
 
 function pre-repo-archive() {
   if [ -d ${OPENSHIFT_REPO_DIR}node_modules ]; then
-    rm -rf ${TMP}node_modules
-    cp -pRf ${OPENSHIFT_REPO_DIR}node_modules ${TMP}
-    rm -rf ${OPENSHIFT_REPO_DIR}node_modules
+    rm -rf ${OPENSHIFT_DATA_DIR}node_modules
+    mv -f ${OPENSHIFT_REPO_DIR}node_modules ${OPENSHIFT_DATA_DIR}
   fi
 }
 
@@ -26,10 +25,10 @@ function build() {
   update_nodejs
   local INIT_DIR=`pwd`
   cd ${OPENSHIFT_REPO_DIR}
-  if [ -d ${TMP}node_modules ]; then
+  if [ -d ${OPENSHIFT_DATA_DIR}node_modules ]; then
     rm -rf ./node_modules
-    cp -pRf ${TMP}node_modules ./
-    rm -rf ${TMP}node_modules
+    mv -f ${OPENSHIFT_DATA_DIR}node_modules ./
+    rm -rf ${OPENSHIFT_DATA_DIR}node_modules
   fi
   npm prune --production
   npm i --production


### PR DESCRIPTION
- Move the node_modules to ${OPENSHIFT_DATA_DIR} instead of ${TMP}
  becuase it is on the same partition and thus it is much faster.
- Move instead of copy because large node.js projects could easily
  exceed the current files quota of 80000 files on the small gears.
- The `mv` was replaced with `rm` and `cp` in 89cdb41 because of issue #30. I believe this error is because in the previous versions the ${TMP}/node_modules was not remove in pre-repo-archive  . See https://bugzilla.redhat.com/show_bug.cgi?id=980061 and http://rhn.redhat.com/errata/RHSA-2013-1652.html
