### PR TITLE
Set default Node.js version to 6.9.0 LTS

### DIFF
--- a/metadata/manifest.yml
+++ b/metadata/manifest.yml
@@ -1,13 +1,13 @@
 Name: nodejs
 Description: Custom Node.js cartridge auto-updating to the latest stable version on each build.
-Version: '6.8.1'
+Version: '6.9.0'
 License: Node.js License
 License-Url: https://raw.githubusercontent.com/nodejs/node/master/LICENSE
 Vendor: www.nodejs.org
 Website: http://www.nodejs.org/
 Display-Name: Node.js Auto-Updating
 Cartridge-Short-Name: NODEJS
-Cartridge-Version: '2.3.5'
+Cartridge-Version: '2.3.6'
 Cartridge-Vendor: icflorescu
 Source-Url: https://github.com/icflorescu/openshift-cartridge-nodejs.git
 Categories:


### PR DESCRIPTION
It's me again, Ionut-Cristian. The Node.js 6.9.0 LTS was just released.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/icflorescu/openshift-cartridge-nodejs/74)

<!-- Reviewable:end -->
